### PR TITLE
chore: fix deprecated gradle expression

### DIFF
--- a/simpledb/app/build.gradle.kts
+++ b/simpledb/app/build.gradle.kts
@@ -9,8 +9,6 @@
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     application
-
-    id("jacoco")
 }
 
 repositories {

--- a/simpledb/app/build.gradle.kts
+++ b/simpledb/app/build.gradle.kts
@@ -9,6 +9,8 @@
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     application
+
+    id("jacoco")
 }
 
 repositories {
@@ -42,18 +44,18 @@ tasks.named<Test>("test") {
 
 task("startServer", JavaExec::class) {
     group = "jdbc"
-    main = "simpledb.server.StartServer"
+    mainClass.value("simpledb.server.StartServer")
     classpath = sourceSets["main"].runtimeClasspath
 }
 
 task("networkclient", JavaExec::class) {
     group = "jdbc"
-    main = "simpledb.client.network.JdbcNetworkDriverExample"
+    mainClass.value("simpledb.client.network.JdbcNetworkDriverExample")
     classpath = sourceSets["main"].runtimeClasspath
 }
 
 task("embeddedclient", JavaExec::class) {
     group = "jdbc"
-    main = "simpledb.client.network.JdbcEmbeddedDriverExample"
+    mainClass.value("simpledb.client.network.JdbcEmbeddedDriverExample")
     classpath = sourceSets["main"].runtimeClasspath
 }


### PR DESCRIPTION
```
The JavaExec.main property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. See https://docs.gradle.org/7.5.1/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main for more details.
        at Build_gradle$5.invoke(build.gradle.kts:47)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

https://docs.gradle.org/7.5.1/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main